### PR TITLE
Fix the build error and add python json parser

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -7,6 +7,7 @@ test:
 	tests/run c
 	tests/run d
 	tests/run e
+	tests/run f
 
 clean:
 	rm -f bin2json

--- a/src/bin2json.c
+++ b/src/bin2json.c
@@ -1,5 +1,5 @@
 #include <stdio.h>
-#include <parse.h>
+#include "parse.h"
 
 int main(int argc, char *argv[]) {
 	if (argc != 2) {

--- a/src/generate_dict.py
+++ b/src/generate_dict.py
@@ -1,20 +1,20 @@
 import json
 from collections import defaultdict
 
-def generate_actor_dict():
+
+def generate_actor_dict() -> None:
     actor_movie_dict = defaultdict(list)
-    
+
     json_list = json.loads(input())
-    
+
     for movie in json_list:
-        for actor in movie.get('cast', []):
-            actor_movie_dict[actor].append(movie.get('title', 'Unknown Title'))
-    
-    with open('actor_movie_dict.json', 'w') as d:
+        for actor in movie.get("cast", []):
+            if title := movie.get("title", ""):
+                actor_movie_dict[actor].append(title)
+
+    with open("actor_movie_dict.json", "w") as d:
         json.dump(actor_movie_dict, d, indent=4)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     generate_actor_dict()
-
-
-

--- a/src/generate_dict.py
+++ b/src/generate_dict.py
@@ -1,0 +1,20 @@
+import json
+from collections import defaultdict
+
+def generate_actor_dict():
+    actor_movie_dict = defaultdict(list)
+    
+    json_list = json.loads(input())
+    
+    for movie in json_list:
+        for actor in movie.get('cast', []):
+            actor_movie_dict[actor].append(movie.get('title', 'Unknown Title'))
+    
+    with open('actor_movie_dict.json', 'w') as d:
+        json.dump(actor_movie_dict, d, indent=4)
+
+if __name__ == '__main__':
+    generate_actor_dict()
+
+
+

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,18 @@
+import json
+import argparse
+
+def retrieve_list_of_movie():
+    parser = argparse.ArgumentParser(description='Retrieve list of movies for a given actor')
+    parser.add_argument('actor_name', help='Actor\'s name')
+    args = parser.parse_args()
+    actor = args.actor_name
+
+    with open("actor_movie_dict.json", "r") as d:
+        actor_movie_dict = json.load(d)
+    movies = '\n'.join(actor_movie_dict.get(actor, []))
+
+    print(movies)
+
+if __name__ == '__main__':
+    retrieve_list_of_movie()
+

--- a/src/main.py
+++ b/src/main.py
@@ -1,18 +1,21 @@
 import json
 import argparse
 
-def retrieve_list_of_movie():
-    parser = argparse.ArgumentParser(description='Retrieve list of movies for a given actor')
-    parser.add_argument('actor_name', help='Actor\'s name')
+
+def retrieve_list_of_movie() -> None:
+    parser = argparse.ArgumentParser(
+        description="Retrieve list of movies for a given actor"
+    )
+    parser.add_argument("actor_name", help="Actor's name")
     args = parser.parse_args()
     actor = args.actor_name
 
     with open("actor_movie_dict.json", "r") as d:
         actor_movie_dict = json.load(d)
-    movies = '\n'.join(actor_movie_dict.get(actor, []))
+    movies = "\n".join(actor_movie_dict.get(actor, []))
 
     print(movies)
 
-if __name__ == '__main__':
-    retrieve_list_of_movie()
 
+if __name__ == "__main__":
+    retrieve_list_of_movie()

--- a/src/parse.c
+++ b/src/parse.c
@@ -51,9 +51,13 @@ int parseString(FILE *fh) {
 		switch (buf[i]) {
 		case '\n':
 			fputs("\\n", stdout);
+			break;
 		case '\\':
+			fputs("\\\\", stdout);
+			break;
 		case '\"':
-			fputs("\\", stdout);
+			fputs("\\\"", stdout);
+			break;
 		default:
 			fprintf(stdout, "%c", buf[i]);
 		}
@@ -84,7 +88,7 @@ int parseNumberInt(FILE *fh) {
 		return ret;
 	}
 
-	fprintf(stdout, "%ld", (int64_t)num);
+	fprintf(stdout, "%lld", (int64_t)num);
 
 	return 0;
 }


### PR DESCRIPTION
This MR is making necessary changes to the bin2json code so that it can be used directly in a singularity file to serve as a parser for movies data.

1. Fix the build by replacing the `<>` to `“”` in `bin2json.c`, which causes a compile error during build.
2. Fix the escape mechanism for `\`, `\n`, `"` in `parse.c`. `break` was added to each end of the `switch-case` statement, and backslash was correctly escaped.
3. Fix the warning during build which stated the `int64_t` variable should correspond to `%lld` rather than `%ld`
4. Add test f in `Makefile`. This test case was failing before the escape mechanism was fixed in 2), and passes after the fix.
5. Add the python scripts to meet the user requirement of outputing a list of movie titles for a given actor provided as command line argument. The `generate_dict.py` converts the output of `bin2json` to a dictionary of actor -> list of movies and stores it in `actor_movie_dict.json`. This generates a smaller-size intermediate file during build and can then be used to conduct fast query via `main.py` when running the container in Singularity.
